### PR TITLE
Fixes invalid nested paragraphs on documents generated from html

### DIFF
--- a/document/fr.opensagres.xdocreport.document.odt/src/test/java/fr/opensagres/xdocreport/document/odt/textstyling/ODTDocumentHandlerTestCase.java
+++ b/document/fr.opensagres.xdocreport.document.odt/src/test/java/fr/opensagres/xdocreport/document/odt/textstyling/ODTDocumentHandlerTestCase.java
@@ -775,7 +775,7 @@ public class ODTDocumentHandlerTestCase
 
         Assert.assertEquals( "", handler.getTextBefore() );
         Assert.assertEquals( "", handler.getTextBody() );
-        Assert.assertEquals( "<text:h text:style-name=\"Heading_20_1\" text:outline-level=\"1\">Title1</text:h><text:p><text:span text:style-name=\"XDocReport_EmptyText\" >text</text:span><text:p><text:span text:style-name=\"XDocReport_EmptyText\" >paragraph</text:span></text:p></text:p>",
+        Assert.assertEquals( "<text:h text:style-name=\"Heading_20_1\" text:outline-level=\"1\">Title1</text:h><text:p><text:span text:style-name=\"XDocReport_EmptyText\" >text</text:span></text:p><text:p><text:span text:style-name=\"XDocReport_EmptyText\" >paragraph</text:span></text:p>",
                              handler.getTextEnd() );
     }
 

--- a/document/fr.opensagres.xdocreport.document.odt/src/test/resources/OOoResult.xml
+++ b/document/fr.opensagres.xdocreport.document.odt/src/test/resources/OOoResult.xml
@@ -72,12 +72,12 @@
     <text:span text:style-name="XDocReport_Bold">bold text</text:span>
     <text:span text:style-name="XDocReport_Italic">italic text </text:span>
     <text:a xlink:href="http://code.google.com/p/xdocreport" xlink:type="simple">XDocReport</text:a>
-    <text:p text:style-name="Standard">
-      <text:span text:style-name="XDocReport_EmptyText">Template style</text:span>
-    </text:p>
-    <text:p text:style-name="XDocReport_P0">
-      <text:span text:style-name="XDocReport_EmptyText">Template style inheritance</text:span>
-    </text:p>
+  </text:p>
+  <text:p text:style-name="Standard">
+    <text:span text:style-name="XDocReport_EmptyText">Template style</text:span>
+  </text:p>
+  <text:p text:style-name="XDocReport_P0">
+    <text:span text:style-name="XDocReport_EmptyText">Template style inheritance</text:span>
   </text:p>
   
 </root>


### PR DESCRIPTION
If the supplied html had a text fragment at the root level followed by a `<p>`, like the example below: 

`<p>Test1</p>a<p>Test2</p>`

The ODTDocumentHandler would create a `<text:p>` and a `<text:span>` to place the text  fragment "a". The following `<p>` would be inserted inside the `<text:p>` already created. Generating the following odt fragment:

```
<text:p>
    <text:span>Test1</text:span>
</text:p>
<text:p>
    <text:span>a</text:span>
    <text:p>
        <text:span>Test2</text:span>
    </text:p>
</text:p>
```

The above fragment is invalid because it has a `<text:p>` as a direct descendant of another `<text:p>`, which is not allowed by the OASIS standard. This would cause the nested paragraph to be ignored by the rendering engine. This change fixes this behavior.
